### PR TITLE
fix(seo): replace em dash with hyphen in metadata titles

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,18 +3,18 @@ import Link from "next/link"
 import { Button } from "@/components/ui/button"
 
 export const metadata: Metadata = {
-  title: { absolute: "OscarPoolVibes — Predict the Oscars with Friends" },
+  title: { absolute: "OscarPoolVibes - Predict the Oscars with Friends" },
   description:
     "Create a pool, invite your friends, and see who can predict the most winners on Hollywood's biggest night.",
   openGraph: {
-    title: "OscarPoolVibes — Predict the Oscars with Friends",
+    title: "OscarPoolVibes - Predict the Oscars with Friends",
     description:
       "Create a pool, invite your friends, and see who can predict the most winners on Hollywood's biggest night.",
     type: "website",
   },
   twitter: {
     card: "summary_large_image",
-    title: "OscarPoolVibes — Predict the Oscars with Friends",
+    title: "OscarPoolVibes - Predict the Oscars with Friends",
     description:
       "Create a pool, invite your friends, and compete on Oscar night.",
   },


### PR DESCRIPTION
The em dash character (U+2014) in OG/Twitter meta titles was being
rendered as garbled text (â€") in some messaging apps and link
preview crawlers that don't handle multi-byte UTF-8 correctly.

https://claude.ai/code/session_01UNndASno3BpqqmX1oKfoYQ