### PR TITLE
fix(seo): replace garbled em dash with hyphen in metadata titles (#81)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,18 +4,18 @@ import { Button } from "@/components/ui/button";
 import { getCachedSession } from "@/lib/auth/session";
 
 export const metadata: Metadata = {
-  title: { absolute: "OscarPoolVibes â€” Predict the Oscars with Friends" },
+  title: { absolute: "OscarPoolVibes - Predict the Oscars with Friends" },
   description:
     "Create a pool, invite your friends, and see who can predict the most winners on Hollywood's biggest night.",
   openGraph: {
-    title: "OscarPoolVibes â€” Predict the Oscars with Friends",
+    title: "OscarPoolVibes - Predict the Oscars with Friends",
     description:
       "Create a pool, invite your friends, and see who can predict the most winners on Hollywood's biggest night.",
     type: "website",
   },
   twitter: {
     card: "summary_large_image",
-    title: "OscarPoolVibes â€” Predict the Oscars with Friends",
+    title: "OscarPoolVibes - Predict the Oscars with Friends",
     description:
       "Create a pool, invite your friends, and compete on Oscar night.",
   },


### PR DESCRIPTION
The em dash character (U+2014) in OG/Twitter meta titles was being
rendered as garbled text (â€") in some messaging apps and link
preview crawlers that don't handle multi-byte UTF-8 correctly.

Resolves the merge conflict from PR #81 by applying the same fix
on the current main branch.

https://claude.ai/code/session_01NgMnAsG7hykjeKq6GCRJqt