### PR TITLE
feat(leaderboard): split correct picks display (#104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **leaderboard:** "Correct" column now shows `X + Y runner-up(s) of Z` — first-choice and runner-up correct picks broken out separately; Z reflects total pool categories (not just predicted ones). Ties count naturally since scoring already awards the same flags for either tied winner.
 - **scoring:** `calculateCategoryScore()` now accepts `tiedWinnerId: string | null`; OR-logic awards points when a prediction matches either tied winner. Non-tied categories behave identically to before.
 - **types:** `SetResultRequest` has optional `tiedWinnerId`; `CategoryResultView` and `ConflictDetail` carry `tiedWinnerId`/`tiedWinnerName`; new `INVALID_TIED_NOMINEE` error code.
 - **docs:** `SCHEMA.md` — `tiedWinnerId` fields documented in Category/Nominee/CategoryResult tables; scoring algorithm pseudocode updated with OR-logic; "Tied Categories" section with historical example added.

--- a/src/components/leaderboard/LeaderboardTable.tsx
+++ b/src/components/leaderboard/LeaderboardTable.tsx
@@ -259,8 +259,14 @@ export function LeaderboardTable({
                   </td>
                   <td className="px-4 py-3 text-center">
                     <span className="text-sm text-muted-foreground">
-                      {entry.correctFirstChoices + entry.correctRunnerUps} /{" "}
-                      {entry.breakdown.length}
+                      {entry.correctFirstChoices}
+                      {entry.correctRunnerUps > 0 && (
+                        <span className="text-muted-foreground/60">
+                          {" "}+{" "}{entry.correctRunnerUps}{" "}
+                          {entry.correctRunnerUps === 1 ? "runner-up" : "runner-ups"}
+                        </span>
+                      )}{" "}
+                      of {categories.length}
                     </span>
                   </td>
                   <td className="px-2 py-3 text-center">


### PR DESCRIPTION
## Summary

- Leaderboard "Correct" column now shows `X + Y runner-up(s) of Z` instead of a single combined total
- When no runner-ups, shows clean `X of Z` (runner-up part hidden)
- `Z` fixed to use `categories.length` (total pool categories) — was previously using `entry.breakdown.length` which only counted categories the user had predicted on
- "runner-up" / "runner-ups" correctly pluralised

Closes #104

## Test plan

- [ ] Player with only first-choice correct picks → shows `X of Z`
- [ ] Player with mixed first/runner-up → shows `X + Y runner-up(s) of Z`
- [ ] Player with exactly 1 runner-up → shows `+ 1 runner-up` (singular)
- [ ] Tied category: winner picked as first-choice → counts in `X`; winner picked as runner-up → counts in `Y`
- [ ] `Z` matches total categories in pool, not prediction count

🤖 Generated with [Claude Code](https://claude.com/claude-code)